### PR TITLE
make pipeline more general for exome bim input and imputed bim input

### DIFF
--- a/variant-annotation/annovar.ipynb
+++ b/variant-annotation/annovar.ipynb
@@ -453,7 +453,9 @@
     "output: f'{cwd}/{_input:bn}.{build}.avinput'\n",
     "task: trunk_workers = 1, walltime = walltime, mem = mem, cores = numThreads, tags = f'{_output:bn}'\n",
     "bash: expand= \"${ }\", stderr = f'{_output:n}.err', stdout = f'{_output:n}.out' \n",
-    "    awk '{if ($2 ~ /D/) {print $1, $4, $4 + (length ($6) - length ($5)), $6, $5, $2} else {print $1, $4, $4, $6, $5, $2}}'  ${_input} >  ${_output}"
+    "    # $6 ref_allele, $5 alt_allele in the bim files \n",
+    "    # Output as annovar avinput chr, start, end (has to be calculated depending on allele length), reference, alternative\n",
+    "    awk '{if ($6 > $5) {print $1, $4, $4 + (length ($6) - length ($5)), $6, $5, $2} else {print $1, $4, $4, $6, $5, $2}}'   ${_input} >  ${_output}"
    ]
   },
   {


### PR DESCRIPTION
make it general for every bim input file (exome or imputed ukbb data)