### PR TITLE
Modified  PCA and GWAS_QC

### DIFF
--- a/GWAS/GWAS_QC.ipynb
+++ b/GWAS/GWAS_QC.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "eb318d07-7143-4bd8-8b3e-bec05edceedf",
    "metadata": {
     "kernel": "SoS"
    },
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "3c16ef1e-9902-4295-9536-76875e3ead55",
    "metadata": {
     "kernel": "SoS"
    },
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "41fa7148-7cc0-4358-b986-d1f80e048b44",
    "metadata": {
     "kernel": "SoS"
    },
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "5da27dcc-5624-46d2-a15b-b4c11f17617f",
    "metadata": {
     "kernel": "SoS"
    },
@@ -87,7 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "",
+   "id": "a5fd3b89-b9e7-4f53-a90f-45baff97eba3",
    "metadata": {
     "kernel": "Bash"
    },
@@ -181,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "",
+   "id": "52f719a0-06ba-448b-821e-16a32570e2a6",
    "metadata": {
     "kernel": "SoS"
    },
@@ -209,7 +209,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "3820dfee-5a1b-4c2c-bc0a-887f88b55d04",
    "metadata": {
     "kernel": "SoS"
    },
@@ -222,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "",
+   "id": "b9ebbff7-2af5-4ae5-8b4e-0d1e19a82616",
    "metadata": {
     "kernel": "SoS"
    },
@@ -443,7 +443,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "9f7075fc-2a40-4c26-b107-8050c826ca07",
    "metadata": {
     "kernel": "SoS"
    },
@@ -458,7 +458,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "",
+   "id": "94c247c0-1084-4b34-bac2-8c5fbb9e2211",
    "metadata": {
     "kernel": "SoS"
    },
@@ -495,11 +495,11 @@
     "bash: container=container_lmm, volumes=[f'{cwd}:{cwd}'], expand= \"${ }\", stderr = f'{_output:n}.stderr', stdout = f'{_output:n}.stdout'\n",
     "    plink2 \\\n",
     "      --bfile ${_input:n} \\\n",
-    "      ${('--maf %s' % maf_filter) if maf_filter >= 0 else ''} \\\n",
+    "      ${('--maf %s' % maf_filter) if maf_filter > 0 else ''} \\\n",
     "      ${('--max-maf %s' % maf_max_filter) if maf_max_filter > 0 else ''} \\\n",
-    "      ${('--geno %s' % geno_filter) if geno_filter >= 0 else ''} \\\n",
-    "      ${('--hwe %s' % hwe_filter) if hwe_filter >= 0 else ''} \\\n",
-    "      ${('--mind %s' % mind_filter) if mind_filter >= 0 else ''} \\\n",
+    "      ${('--geno %s' % geno_filter) if geno_filter > 0 else ''} \\\n",
+    "      ${('--hwe %s' % hwe_filter) if hwe_filter > 0 else ''} \\\n",
+    "      ${('--mind %s' % mind_filter) if mind_filter > 0 else ''} \\\n",
     "      ${('--keep %s' % keep_samples) if keep_samples.is_file() else \"\"} \\\n",
     "      ${('--remove %s' % remove_samples) if remove_samples.is_file() else \"\"} \\\n",
     "      ${('--extract %s' % keep_variants) if keep_variants.is_file() else \"\"} \\\n",
@@ -512,7 +512,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "",
+   "id": "20eddb35-3ebc-41f9-9cef-33e88e1948d2",
    "metadata": {
     "kernel": "SoS"
    },
@@ -547,7 +547,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "",
+   "id": "ccf959ed-6c9b-4aef-a914-9bbd5209451c",
    "metadata": {
     "kernel": "SoS"
    },
@@ -563,7 +563,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "",
+   "id": "78772bf5-c501-4ad6-b41c-e3b88e73ad26",
    "metadata": {
     "kernel": "SoS"
    },

--- a/GWAS/LMM.ipynb
+++ b/GWAS/LMM.ipynb
@@ -2398,7 +2398,7 @@
     "displayed": true,
     "height": 0
    },
-   "version": "0.22.9"
+   "version": "0.22.6"
   },
   "toc-showcode": false
  },

--- a/GWAS/PCA.ipynb
+++ b/GWAS/PCA.ipynb
@@ -36,7 +36,7 @@
     "## Input\n",
     "\n",
     "1. Genotype in PLINK format: could be different from bfile in the case of using for e.g. exome data / imputed genotype data\n",
-    "2. Phentype files with population information and possibly disease or other labelling information, must contain columns named 'FID' and 'IID' for family ID and individual ID. **FIXME: can we require only IID and in our code create FID by setting it to IID if FID does not exist?**\n",
+    "2. Phenotype files with population information and possibly disease or other labelling information, must contain columns named 'FID' and 'IID' for family ID and individual ID. If you do not have a phenotype file you can inpute a fam file **FIXME: can we require only IID and in our code create FID by setting it to IID if FID does not exist?**\n",
     "\n",
     "The inputs should be splitted into sets of related and unrelated individuals. Additionally you may want to prepare data per population. See \"How to run this workflow\" section for more details.\n",
     "\n",
@@ -166,7 +166,9 @@
     "sos run PCA.ipynb flashpca \\\n",
     "    --genoFile <unrelated_samples.bed>\n",
     "    --phenoFile <phenotypes.txt>\n",
-    "```"
+    "```\n",
+    "\n",
+    "If your phenoFile has a categorical variable with the ethnicity or population you can use `label_col` parameter to define it, so that the plot generated has different colors depending on the population"
    ]
   },
   {
@@ -182,7 +184,9 @@
     "    --pca-model <unrelated_samples.pca.rds> \\\n",
     "    --genoFile <related_samples.bed> \\\n",
     "    --phenoFile <phenotypes.txt>\n",
-    "```"
+    "```\n",
+    "\n",
+    "Same as above, if you have an ethnicity variable you can specify it by using `label_col` and here you would also need to add `pop_col` that points to the same variable. This is necessary, otherwise the detect_outliers part of the workflow will error. \n"
    ]
   },
   {
@@ -1183,7 +1187,7 @@
     "    if (${\"TRUE\" if outlier_file.is_file() else \"FALSE\"}) {\n",
     "        outliers <- read.table(${outlier_file:r}, col.names=c(\"FID\", \"IID\"),stringsAsFactors =F)\n",
     "        plot_pcs = function(pca_final, x, y, title=\"\") {\n",
-    "            ggplot(pca_final, aes_string(x=x, y=y)) + geom_point(${f'aes(color={label_col}, size=1)' if label_col else \"\"}) + \n",
+    "            ggplot(pca_final, aes_string(x=x, y=y)) + geom_point(${f'aes(color={label_col})' if label_col else \"\"}) + \n",
     "              # add circles for these ouliters:\n",
     "              geom_point(data=filter(pca_final, IID %in% outliers$IID, FID %in% outliers$FID), shape = 21, size=1.5, color='red', stroke = 0.9) +\n",
     "              # add outliers dots:\n",
@@ -1195,7 +1199,7 @@
     "              theme_classic()\n",
     "        }} else {\n",
     "        plot_pcs = function(pca_final, x, y, title=\"\") {\n",
-    "          ggplot(pca_final, aes_string(x=x, y=y)) + geom_point(${f'aes(color={label_col}, size=1)' if label_col else \"\"}) + \n",
+    "          ggplot(pca_final, aes_string(x=x, y=y)) + geom_point(${f'aes(color={label_col})' if label_col else \"\"}) + \n",
     "              labs(title=title,x=x, y=y) +\n",
     "              scale_y_continuous(limits=c(min_axis, max_axis)) +\n",
     "              scale_x_continuous(limits=c(min_axis, max_axis)) +\n",


### PR DESCRIPTION
In the PCA:
Added extra instruction on how to use label_col and pop_col when submitting a script
Removed the size=1 in the plotting of the PCA (the dots were too big)
in the GWAS_QC
The filters have to be > 0 and not >= 0 because the default is 0 if the equal is present it will still filter out using the 0 threshold (We had already discussed this with @gaow and I don't know why this changes weren't there)
   ${('--maf %s' % maf_filter) if maf_filter > 0 else ''} \
      ${('--geno %s' % geno_filter) if geno_filter > 0 else ''} \
      ${('--hwe %s' % hwe_filter) if hwe_filter > 0 else ''} \
      ${('--mind %s' % mind_filter) if mind_filter > 0 else ''} \